### PR TITLE
Better error handling when sending too many requests

### DIFF
--- a/RocketChatBot.py
+++ b/RocketChatBot.py
@@ -88,6 +88,9 @@ class RocketChatBot(object):
 
     def process_messages(self, messages, channel_id):
         try:
+            if "success" in messages:
+                if messages['success'] == False:
+                    raise RuntimeError(messages['error'])
             if len(messages['messages']) > 0:
                 self.lastts[channel_id] = messages['messages'][0]['ts']
             self.handle_messages(messages, channel_id)


### PR DESCRIPTION
I created a PR for the KeyError('messages') issue. It doesn't fix the exception, it just shows the real error message, which are in my case to many API calls.


A possible solution might be to raise the limits: see https://forums.rocket.chat/t/api-error-too-many-requests/1694